### PR TITLE
Preserve color space when saving Arnold textures

### DIFF
--- a/Maya/MAYA_APP_DIR/modules/DazToMaya/scripts/d2m.py
+++ b/Maya/MAYA_APP_DIR/modules/DazToMaya/scripts/d2m.py
@@ -2706,10 +2706,12 @@ def btn_save_with_text_callback():
             just_file_name = os.path.basename(image_path)
             out_file_name = out_path + "images/" + str(just_file_name)
             if image_path != out_file_name:
+                color_space = file_node.getAttr('colorSpace')
                 from shutil import copyfile
                 copyfile(image_path, out_file_name)
                 file_node.setAttr('fileTextureName',
                                  "images/" + str(just_file_name))
+                file_node.setAttr('colorSpace', color_space)
 
         cmds.file(rename=save_file_result[0])
         if ".ma" in save_file_result[0]:


### PR DESCRIPTION
When saving a scene with textures the change of the fileTextureName attribute causes color space to change to the default value which is sRGB. With this fix, a correct color space is preserved.

Maya version: 2020
**How to replicate the bug:**
1. Launch DazToMaya window
2. Click Auto-Import
3. Click Convert Materials (Arnold is selected)
4. Click Save Scene with Textures...
5. Write file name and save
6. In hypershade (or anywhere else) look at any texture that should have raw color space

What we can see: All textures have sRGB color space (depends on Maya settings, but sRGB is the default).
Expected: sRGB or RAW depending on the texture.

**What is fixed in this pull request: Textures preserve their original color space and we can see in the texture node that it has the correct color space.**